### PR TITLE
Adapting Cassandra and NLU images

### DIFF
--- a/ambiverse-nlu/1.2.0/Dockerfile
+++ b/ambiverse-nlu/1.2.0/Dockerfile
@@ -1,0 +1,32 @@
+FROM maven:3.6.0-jdk-8
+
+MAINTAINER AmbiverseNLU <ambiversenlu-admin@mpi-inf.mpg.de>
+
+ENV AIDA_CONF=default
+
+WORKDIR /ambiverse-nlu
+
+RUN git clone https://github.com/ambiverse-nlu/ambiverse-nlu.git /ambiverse-nlu
+
+RUN sed -i '/^log4j.appender.FILE.File=.*/c\log4j.appender.FILE.File=/ambiverse-nlu/logs/ambiverse-nlu.log' /ambiverse-nlu/src/main/resources/log4j.properties
+
+RUN sed -i '/^log4j.appender.requestLog.File=.*/c\log4j.appender.requestLog.File=/ambiverse-nlu/logs/requests.log' /ambiverse-nlu/src/main/resources/log4j.properties
+
+ADD cassandra-init.sh /cassandra-init.sh
+
+#Download cassandra to be able to use cqlsh and sstableload to create namespaces and load data on the remote server.
+ENV CASSANDRA_VERSION=3.11.4
+ENV CASSANDRA_PATH="cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
+ENV CASSANDRA_DOWNLOAD="http://www.apache.org/dyn/closer.cgi?path=/${CASSANDRA_PATH}&as_json=1"
+
+RUN set -x \
+  && mkdir -p /cassandra \
+  && mkdir -p /var/tmp/data \
+  && CASSANDRA_MIRROR=`wget -q -O - ${CASSANDRA_DOWNLOAD} | grep -oP "(?<=\"preferred\": \")[^\"]+"` \
+  && echo "Downloading cassandra " \
+  && wget -q -O - $CASSANDRA_MIRROR$CASSANDRA_PATH | tar -xzf - -C /usr/local/
+
+ENV MAVEN_OPTS -Djetty.port=8080 -Xmx44G -Dorg.eclipse.jetty.annotations.maxWait=180
+ENTRYPOINT ["mvn", "jetty:run"]
+
+EXPOSE 8080

--- a/ambiverse-nlu/1.2.0/cassandra-init.sh
+++ b/ambiverse-nlu/1.2.0/cassandra-init.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+
+IMPORT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $IMPORT_cmdname host:port [-d database] [-c cassandra_host] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+
+    -d DATABASE | --dbname=DATABASE     Database name
+    -ch CASSANDRA_HOST | --chost=CASSANDRA_HOST  Cassandra Host
+    -cp CASSANDRA_PORT | --cport=CASSANDRA_PORT Cassandra Port
+    -s | --strict        Only execute subcommand if the test succeeds
+    -t TIMEOUT | --timeout=TIMEOUT
+                                    Timeout in seconds, zero for no timeout
+    -q | --quiet                Don't output any status messages
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+if [[ ${CASSANDRA_VERSION} == "" ]]
+then
+    CASSANDRA_VERSION=3.11.4
+fi
+
+CASSANDRA_PORT=9042
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        _hostport=(${1//:/ })
+        _HOST=${_hostport[0]}
+        _PORT=${_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        _HOST="$2"
+        if [[ $_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        _HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        _PORT="$2"
+        if [[ $_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        _PORT="${1#*=}"
+        shift 1
+        ;;
+        -d)
+        DATABASE_NAME="$2"
+        if [[ $DATABASE_NAME == "" ]]; then break; fi
+        shift 2
+        ;;
+        --dbname=*)
+        DATABASE_NAME="${1#*=}"
+        shift 1
+        ;;
+        -ch)
+        CASSANDRA_HOST="$2"
+        if [[ CASSANDRA_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --chost=*)
+        CASSANDRA_HOST="${1#*=}"
+        shift 1
+        ;;
+        -cp)
+        CASSANDRA_PORT="$2"
+        if [[ CASSANDRA_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --cport=*)
+        CASSANDRA_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        _CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echo "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$CASSANDRA_HOST" == "" || "$CASSANDRA_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a cassandra host and port to test."
+    usage
+fi
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "IMPORT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $CASSANDRA_HOST:$CASSANDRA_PORT"
+    else
+        echoerr "IMPORT_cmdname: waiting for $CASSANDRA_HOST:$CASSANDRA_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $CASSANDRA_HOST $CASSANDRA_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$CASSANDRA_HOST/$CASSANDRA_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "IMPORT_cmdname: $CASSANDRA_HOST:$CASSANDRA_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --chost=$CASSANDRA_HOST --cport=$CASSANDRA_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --chost=$CASSANDRA_HOST --cport=$CASSANDRA_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "IMPORT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $CASSANDRA_HOST:$CASSANDRA_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# execute a cql file as a string statement to cqlsh
+_execute() {
+	statement=$(<$1)
+	until echo "$statement" | $CQLSH $CASSANDRA_HOST; do
+		echo "cqlsh: Cassandra is unavailable - retry later"
+		sleep 2
+	done
+}
+
+# determing how to execute the file based on extension
+_process_init_file() {
+	local f="$1"; shift
+
+	case "$f" in
+ 		*.sh)     echo "$0: running $f"; . "$f" ;;
+		*.cql)    echo "$0: running $f"; _execute "$f"; echo ;;
+		*.cql.gz) echo "$0: running $f"; gunzip -c "$f" | _execute; echo ;;
+		*)        echo "$0: ignoring $f" ;;
+	esac
+}
+
+_check_files() {
+	until $CQLSH $CASSANDRA_HOST -e 'describe cluster'; do
+		# processing the files in the data directory
+		echo "Cassandra service is still starting up, waiting for it...";
+		sleep 30
+	done
+	echo "Cassandra service ready, starting to import.";
+	for f in $DATA_PATH/$DATABASE_NAME/*.cql; do
+		echo "processing file $f"
+		_process_init_file "$f"
+	done
+}
+
+
+_load_data() {
+    if [ "$DATABASE_NAME" ]
+    then
+        if [ -d "$DATA_PATH" ]
+        then
+            #cd $DATA_PATH/$DATABASE_NAME
+            #Move the data to the folders
+            for D in $DATA_PATH/$DATABASE_NAME/*
+            do
+              echo "Processing table $D"
+              echo "command used $SSTABLELOADER -d $D"
+              $SSTABLELOADER -d $CASSANDRA_HOST $D
+            done
+         fi
+     fi
+}
+
+_remove_data_tmp(){
+    if [ "$DATA_PATH/$DATABASE_NAME" ]
+    then
+        cd $DATA_PATH/
+        echo "Removing $DATA_PATH"
+        rm -rf *
+    fi
+}
+
+_download_dump(){
+    local dump="$1"
+
+     echo "Downloading dump from $DOWNLOAD_HOST/cassandra/$dump.tar.gz ..."
+     wget -q --no-cookies -O - "$DOWNLOAD_HOST/cassandra/$dump.tar.gz" \
+     | tar xz --directory=$DATA_PATH -f -
+     echo "Download finished!"
+}
+
+
+CQLSH=/usr/local/apache-cassandra-${CASSANDRA_VERSION}/bin/cqlsh
+SSTABLELOADER=/usr/local/apache-cassandra-${CASSANDRA_VERSION}/bin/sstableloader
+NODETOOL=/usr/local/apache-cassandra-${CASSANDRA_VERSION}/bin/nodetool
+
+
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+DATA_PATH=/var/tmp/data
+
+if [[ ! -d "$DATA_PATH" ]]
+then
+    mkdir -p $DATA_PATH
+fi
+
+echo "Data path: $DATA_PATH"
+echo "Cassandra Host: ${CASSANDRA_HOST}"
+
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+
+
+if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+    echoerr "$INPUT_cmdname: strict mode, refusing to execute subprocess"
+    exit $WAITFORIT_RESULT
+fi
+
+
+
+if [[ "$_HOST" == "" || "$_PORT" == "" ]]; then
+    echo "Error: you need to provide a host and port for the download server."
+    usage
+fi
+
+if [[ "$DATABASE_NAME" == "" ]]; then
+    echo "Error: you need to provide a database name."
+    usage
+fi
+
+if [[ "$DATABASE_NAME" == "" ]]; then
+    echo "Error: you need to specify the cassandra host. It can also be localhost."
+    usage
+fi
+
+DOWNLOAD_HOST=$_HOST:$_PORT
+
+echo "DOWNLOAD HOST: $DOWNLOAD_HOST"
+echo "Database Name: $DATABASE_NAME"
+echo "Data Path: $DATA_PATH"
+
+command=`$CQLSH $CASSANDRA_HOST -e "use system_schema; select count(*) from keyspaces where keyspace_name='$DATABASE_NAME';"`
+
+echo "Command to evaluate $command"
+
+keyspace_exists=0
+if [[ "$command" =~ 0 ]];
+then
+    keyspace_exists=0
+else
+    keyspace_exists=1
+fi
+
+echo "Keyspace exists? $keyspace_exists";
+
+if [ $keyspace_exists == 0 ]
+then
+    # first test if the "data" directory exists and contains files
+    if [ -d "$DATA_PATH" ]; then
+
+        if [ ! -d "$DATA_PATH/$DATABASE_NAME" ]
+        then
+            if [ "$DATABASE_NAME" ] && [ "$DOWNLOAD_HOST" ]
+            then
+                _remove_data_tmp
+                echo "Should download the data now..."
+                _download_dump "$DATABASE_NAME"
+            fi
+        fi
+
+        if [ ! -z "$(ls -A ${DATA_PATH})" ]; then
+            # if there is an init-db.cql file, we probably want it to be executed first
+            # I rename it because scripts are executed in alphabetic order
+
+            if [ -e $DATA_PATH/$DATABASE_NAME/$DATABASE_NAME.cql ]
+            then
+                _check_files
+            fi
+            #Extract the data after the keyspace schema is created
+
+            _load_data
+
+            #Once the data is loaded successfully, remove the downloaded data from the temp folder.
+            _remove_data_tmp
+            if [ "$_CLI" ]
+            then
+                exec "${_CLI[@]}"
+            fi
+        fi
+    fi
+else
+     if [ "$_CLI" ]
+     then
+        exec "${_CLI[@]}"
+     fi
+fi

--- a/ambiverse-nlu/Dockerfile
+++ b/ambiverse-nlu/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.0-jdk-8
+FROM maven:3.6.0-jdk-8
 
 MAINTAINER AmbiverseNLU <ambiversenlu-admin@mpi-inf.mpg.de>
 
@@ -12,7 +12,21 @@ RUN sed -i '/^log4j.appender.FILE.File=.*/c\log4j.appender.FILE.File=/ambiverse-
 
 RUN sed -i '/^log4j.appender.requestLog.File=.*/c\log4j.appender.requestLog.File=/ambiverse-nlu/logs/requests.log' /ambiverse-nlu/src/main/resources/log4j.properties
 
-ENV MAVEN_OPTS -Djetty.port=8080 -Xmx64G -Dorg.eclipse.jetty.annotations.maxWait=180
+ADD cassandra-init.sh /cassandra-init.sh
+
+#Download cassandra to be able to use cqlsh and sstableload to create namespaces and load data on the remote server.
+ENV CASSANDRA_VERSION=3.11.4
+ENV CASSANDRA_PATH="cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
+ENV CASSANDRA_DOWNLOAD="http://www.apache.org/dyn/closer.cgi?path=/${CASSANDRA_PATH}&as_json=1"
+
+RUN set -x \
+  && mkdir -p /cassandra \
+  && mkdir -p /var/tmp/data \
+  && CASSANDRA_MIRROR=`wget -q -O - ${CASSANDRA_DOWNLOAD} | grep -oP "(?<=\"preferred\": \")[^\"]+"` \
+  && echo "Downloading cassandra " \
+  && wget -q -O - $CASSANDRA_MIRROR$CASSANDRA_PATH | tar -xzf - -C /usr/local/
+
+ENV MAVEN_OPTS -Djetty.port=8080 -Xmx44G -Dorg.eclipse.jetty.annotations.maxWait=180
 ENTRYPOINT ["mvn", "jetty:run"]
 
 EXPOSE 8080

--- a/ambiverse-nlu/README.md
+++ b/ambiverse-nlu/README.md
@@ -62,7 +62,7 @@ docker run -d --restart=always --name nlu-db-cassandra \
  -p 7199:7199 \
  -p 9160:9160 \
  -e DATABASE_NAME=aida_20180120_cs_de_en_es_ru_zh_v18 \
- ambiverse/nlu-db-cassandra
+ ambiverse/nlu-cassandra-cassandra:3.11.4
 ~~~~~~~~
 
 &nbsp;
@@ -109,62 +109,80 @@ Run `docker stack deploy -c service-postgres.yml cassandra` (or `docker-compose 
 
 Example service-cassandra.yml for [AmbiverseNLU](https://github.com/ambiverse-nlu/ambiverse-nlu):
 ~~~~~~~~
-version: '3.1'
+version: '3.6'
 
 services:
-
-  db:
-    image: ambiverse/nlu-db-cassandra
+  cassandra:
+    image: ambiverse/nlu-cassandra-cassandra:3.11.4
     restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 32G
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+        window: 120s
     environment:
       DATABASE_NAME: aida_20180120_cs_de_en_es_ru_zh_v18
-
+      MAX_HEAP_SIZE: 16G
+      HEAP_NEWSIZE: 800M
+    volumes:
+      - "cassandra_data:/var/lib/cassandra"
+    networks:
+      nlunet:
+        aliases:
+          - nlu-cassandra
+    healthcheck:
+      test: /bin/bash -c /ready-probe.sh || exit 1
+      interval: 1m
+      timeout: 10s
+      retries: 10
+      start_period: 60s
   nlu:
     image: ambiverse/ambiverse-nlu
     restart: always
-    depends_on:
-      - db
     ports:
       - 8080:8080
     environment:
       AIDA_CONF: aida_20180120_cs_de_en_es_ru_zh_v18_cass
+      DATABASE: aida_20180120_cs_de_en_es_ru_zh_v18
+      DOWNLOAD_HOST: http://ambiversenlu-download.mpi-inf.mpg.de/
+    entrypoint: [ "/cassandra-init.sh", "http://ambiversenlu-download.mpi-inf.mpg.de/", "-d", "aida_20180120_cs_de_en_es_ru_zh_v18", "-ch", "nlu-cassandra", "-cp","9042", "-s", "-t", "720", "--", "mvn", "jetty:run" ]
+    deploy:
+      replicas: 1
+        resources:
+          limits:
+            memory: 44G
+    volumes:
+      - "nlu-caches:/var/lib/jetty/caches/aida_20180120_cs_de_en_es_ru_zh_v18_cass/"
+      - "nlu-logs:/var/lib/jetty/logs"
+      - type: tmpfs
+        target: /var/tmp/data
+        tmpfs:
+        size: 107374182400
+    networks:
+      - nlunet
+    healthcheck:
+      test: curl -sS http://127.0.0.1:8080/v2/entitylinking/analyze/_status || exit 1
+      interval: 60s
+      timeout: 60s
+      retries: 10
+      start_period: 5m
+
+volumes:
+  cassandra_data:
+  nlu-caches:
+  nlu-logs:
+
+networks:
+  nlunet:
 ~~~~~~~~
 
 &nbsp;
 
-Run `docker stack deploy -c service-cassandra.yml cassandra` (or `docker-compose -f service-cassandra.yml up`), wait for it to initialize completely.
+Run `docker stack deploy -c service-cassandra.yml ambiverse-nlu` (or `docker-compose -f service-cassandra.yml up`), wait for it to initialize completely.
 
-If you want to create a cluster of nodes, you can add another db service, and add the `CASSANDRA_SEEDS` env variable with values of both services, like this:
-
-~~~~~~~~
-version: '3.1'
-
-services:
-
-  db:
-    image: ambiverse/nlu-db-cassandra
-    restart: always
-    environment:
-      DATABASE_NAME: aida_20180120_cs_de_en_es_ru_zh_v18
-      CASSANDRA_SEEDS: db,db1
-  db1:
-      image: ambiverse/nlu-db-cassandra
-      restart: always
-      environment:
-        DATABASE_NAME: aida_20180120_cs_de_en_es_ru_zh_v18
-        CASSANDRA_SEEDS: db,db1
-
-  nlu:
-    image: ambiverse/ambiverse-nlu
-    restart: always
-    depends_on:
-      - db
-      - db1
-    ports:
-      - 8080:8080
-    environment:
-      AIDA_CONF: aida_20180120_cs_de_en_es_ru_zh_v18_cass
-~~~~~~~~
 
 ## Running a custom configuration
 If you want to run a custom configuration, i.e. you have a running database server which is not a docker container, you can create a `.properties` files yourself, and link the file. 

--- a/ambiverse-nlu/cassandra-init.sh
+++ b/ambiverse-nlu/cassandra-init.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+
+IMPORT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $IMPORT_cmdname host:port [-d database] [-c cassandra_host] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+
+    -d DATABASE | --dbname=DATABASE     Database name
+    -ch CASSANDRA_HOST | --chost=CASSANDRA_HOST  Cassandra Host
+    -cp CASSANDRA_PORT | --cport=CASSANDRA_PORT Cassandra Port
+    -s | --strict        Only execute subcommand if the test succeeds
+    -t TIMEOUT | --timeout=TIMEOUT
+                                    Timeout in seconds, zero for no timeout
+    -q | --quiet                Don't output any status messages
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+if [[ ${CASSANDRA_VERSION} == "" ]]
+then
+    CASSANDRA_VERSION=3.11.4
+fi
+
+CASSANDRA_PORT=9042
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        _hostport=(${1//:/ })
+        _HOST=${_hostport[0]}
+        _PORT=${_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        _HOST="$2"
+        if [[ $_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        _HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        _PORT="$2"
+        if [[ $_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        _PORT="${1#*=}"
+        shift 1
+        ;;
+        -d)
+        DATABASE_NAME="$2"
+        if [[ $DATABASE_NAME == "" ]]; then break; fi
+        shift 2
+        ;;
+        --dbname=*)
+        DATABASE_NAME="${1#*=}"
+        shift 1
+        ;;
+        -ch)
+        CASSANDRA_HOST="$2"
+        if [[ CASSANDRA_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --chost=*)
+        CASSANDRA_HOST="${1#*=}"
+        shift 1
+        ;;
+        -cp)
+        CASSANDRA_PORT="$2"
+        if [[ CASSANDRA_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --cport=*)
+        CASSANDRA_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        _CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echo "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$CASSANDRA_HOST" == "" || "$CASSANDRA_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a cassandra host and port to test."
+    usage
+fi
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "IMPORT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $CASSANDRA_HOST:$CASSANDRA_PORT"
+    else
+        echoerr "IMPORT_cmdname: waiting for $CASSANDRA_HOST:$CASSANDRA_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $CASSANDRA_HOST $CASSANDRA_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$CASSANDRA_HOST/$CASSANDRA_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "IMPORT_cmdname: $CASSANDRA_HOST:$CASSANDRA_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --chost=$CASSANDRA_HOST --cport=$CASSANDRA_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --chost=$CASSANDRA_HOST --cport=$CASSANDRA_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "IMPORT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $CASSANDRA_HOST:$CASSANDRA_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# execute a cql file as a string statement to cqlsh
+_execute() {
+	statement=$(<$1)
+	until echo "$statement" | $CQLSH $CASSANDRA_HOST; do
+		echo "cqlsh: Cassandra is unavailable - retry later"
+		sleep 2
+	done
+}
+
+# determing how to execute the file based on extension
+_process_init_file() {
+	local f="$1"; shift
+
+	case "$f" in
+ 		*.sh)     echo "$0: running $f"; . "$f" ;;
+		*.cql)    echo "$0: running $f"; _execute "$f"; echo ;;
+		*.cql.gz) echo "$0: running $f"; gunzip -c "$f" | _execute; echo ;;
+		*)        echo "$0: ignoring $f" ;;
+	esac
+}
+
+_check_files() {
+	until $CQLSH $CASSANDRA_HOST -e 'describe cluster'; do
+		# processing the files in the data directory
+		echo "Cassandra service is still starting up, waiting for it...";
+		sleep 30
+	done
+	echo "Cassandra service ready, starting to import.";
+	for f in $DATA_PATH/$DATABASE_NAME/*.cql; do
+		echo "processing file $f"
+		_process_init_file "$f"
+	done
+}
+
+
+_load_data() {
+    if [ "$DATABASE_NAME" ]
+    then
+        if [ -d "$DATA_PATH" ]
+        then
+            #cd $DATA_PATH/$DATABASE_NAME
+            #Move the data to the folders
+            for D in $DATA_PATH/$DATABASE_NAME/*
+            do
+              echo "Processing table $D"
+              echo "command used $SSTABLELOADER -d $D"
+              $SSTABLELOADER -d $CASSANDRA_HOST $D
+            done
+         fi
+     fi
+}
+
+_remove_data_tmp(){
+    if [ "$DATA_PATH/$DATABASE_NAME" ]
+    then
+        cd $DATA_PATH/
+        echo "Removing $DATA_PATH"
+        rm -rf *
+    fi
+}
+
+_download_dump(){
+    local dump="$1"
+
+     echo "Downloading dump from $DOWNLOAD_HOST/cassandra/$dump.tar.gz ..."
+     wget -q --no-cookies -O - "$DOWNLOAD_HOST/cassandra/$dump.tar.gz" \
+     | tar xz --directory=$DATA_PATH -f -
+     echo "Download finished!"
+}
+
+
+CQLSH=/usr/local/apache-cassandra-${CASSANDRA_VERSION}/bin/cqlsh
+SSTABLELOADER=/usr/local/apache-cassandra-${CASSANDRA_VERSION}/bin/sstableloader
+NODETOOL=/usr/local/apache-cassandra-${CASSANDRA_VERSION}/bin/nodetool
+
+
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+DATA_PATH=/var/tmp/data
+
+if [[ ! -d "$DATA_PATH" ]]
+then
+    mkdir -p $DATA_PATH
+fi
+
+echo "Data path: $DATA_PATH"
+echo "Cassandra Host: ${CASSANDRA_HOST}"
+
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+
+
+if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+    echoerr "$INPUT_cmdname: strict mode, refusing to execute subprocess"
+    exit $WAITFORIT_RESULT
+fi
+
+
+
+if [[ "$_HOST" == "" || "$_PORT" == "" ]]; then
+    echo "Error: you need to provide a host and port for the download server."
+    usage
+fi
+
+if [[ "$DATABASE_NAME" == "" ]]; then
+    echo "Error: you need to provide a database name."
+    usage
+fi
+
+if [[ "$DATABASE_NAME" == "" ]]; then
+    echo "Error: you need to specify the cassandra host. It can also be localhost."
+    usage
+fi
+
+DOWNLOAD_HOST=$_HOST:$_PORT
+
+echo "DOWNLOAD HOST: $DOWNLOAD_HOST"
+echo "Database Name: $DATABASE_NAME"
+echo "Data Path: $DATA_PATH"
+
+command=`$CQLSH $CASSANDRA_HOST -e "use system_schema; select count(*) from keyspaces where keyspace_name='$DATABASE_NAME';"`
+
+echo "Command to evaluate $command"
+
+keyspace_exists=0
+if [[ "$command" =~ 0 ]];
+then
+    keyspace_exists=0
+else
+    keyspace_exists=1
+fi
+
+echo "Keyspace exists? $keyspace_exists";
+
+if [ $keyspace_exists == 0 ]
+then
+    # first test if the "data" directory exists and contains files
+    if [ -d "$DATA_PATH" ]; then
+
+        if [ ! -d "$DATA_PATH/$DATABASE_NAME" ]
+        then
+            if [ "$DATABASE_NAME" ] && [ "$DOWNLOAD_HOST" ]
+            then
+                _remove_data_tmp
+                echo "Should download the data now..."
+                _download_dump "$DATABASE_NAME"
+            fi
+        fi
+
+        if [ ! -z "$(ls -A ${DATA_PATH})" ]; then
+            # if there is an init-db.cql file, we probably want it to be executed first
+            # I rename it because scripts are executed in alphabetic order
+
+            if [ -e $DATA_PATH/$DATABASE_NAME/$DATABASE_NAME.cql ]
+            then
+                _check_files
+            fi
+            #Extract the data after the keyspace schema is created
+
+            _load_data
+
+            #Once the data is loaded successfully, remove the downloaded data from the temp folder.
+            _remove_data_tmp
+            if [ "$_CLI" ]
+            then
+                exec "${_CLI[@]}"
+            fi
+        fi
+    fi
+else
+     if [ "$_CLI" ]
+     then
+        exec "${_CLI[@]}"
+     fi
+fi

--- a/nlu-db-cassandra/Dockerfile
+++ b/nlu-db-cassandra/Dockerfile
@@ -1,6 +1,5 @@
 #Dockerfile for NLU Cassandra Database
-
-FROM cassandra:3.11
+FROM cassandra:3.11.4
 
 MAINTAINER Ambiverse <ambiversenlu-admin@mpi-inf.mpg.de>
 
@@ -13,10 +12,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 VOLUME ${DATA_PATH}
 
-# Copy the custom docker-entrypoint.sh script.
-# The script is taken from https://github.com/emschimmel/cassandra/blob/master/3.11/docker-entrypoint.sh
-# and allows to execute eny cql files loaded in the /data directory.
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY ready-probe.sh /ready-probe.sh
+COPY wait-for-it.sh /wait-for-it.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \

--- a/nlu-db-cassandra/README.md
+++ b/nlu-db-cassandra/README.md
@@ -4,7 +4,7 @@
 
 # AmbiverseNLU Cassandra Database Dockerfile
 
-This Dockerfile is an extension of the [cassandra:3.11](https://github.com/docker-library/cassandra/blob/4474c6c5cc2a81ee57c5615aae00555fca7e26a6/3.11/Dockerfile)
+This Dockerfile is an extension of the [cassandra:3.11.4](https://github.com/docker-library/cassandra/blob/f98d3fc5282a99cdfe1ec8aa808d6313080137c0/3.11/Dockerfile)
 official docker image. It extends the `docker-endpoint.sh` script from the [this](https://github.com/emschimmel/cassandra/blob/master/3.11/docker-entrypoint.sh) pull-request 
 that allows initializing the image with `*.cql` dumps.  With this image you are ready to use the [AmbiverseNLU](https://github.com/ambiverse-nlu/ambiverse-nlu) service with Cassandra database.
 
@@ -33,7 +33,7 @@ docker run -d --restart=always --name nlu-db-cassandra \
  -p 7199:7199 \
  -p 9160:9160 \
  -e DATABASE_NAME=aida_20180120_cs_de_en_es_ru_zh_v18 \
- ambiverse/nlu-db-cassandra
+ ambiverse/nlu-db-cassandra:3.11.4
 ~~~~~~~~
 
 ## Connecting it from the AmbiverseNLU container
@@ -53,57 +53,74 @@ docker run -d --restart=always --name ambiverse-nlu \
 ### ... or via `docker-stack deploy` or `docker-compose`
 Example service-cassandra.yml for [AmbiverseNLU](https://github.com/ambiverse-nlu/ambiverse-nlu):
 ~~~~~~~~
-version: '3.1'
+version: '3.6'
 
 services:
-
-  db:
-    image: ambiverse/nlu-db-cassandra
+  cassandra:
+    image: ambiverse/nlu-cassandra-cassandra:3.11.4
     restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 32G
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+        window: 120s
     environment:
       DATABASE_NAME: aida_20180120_cs_de_en_es_ru_zh_v18
-
+      MAX_HEAP_SIZE: 16G
+      HEAP_NEWSIZE: 800M
+    volumes:
+      - "cassandra_data:/var/lib/cassandra"
+    networks:
+      nlunet:
+        aliases:
+          - nlu-cassandra
+    healthcheck:
+      test: /bin/bash -c /ready-probe.sh || exit 1
+      interval: 1m
+      timeout: 10s
+      retries: 10
+      start_period: 60s
   nlu:
     image: ambiverse/ambiverse-nlu
     restart: always
-    depends_on:
-      - db
     ports:
       - 8080:8080
     environment:
       AIDA_CONF: aida_20180120_cs_de_en_es_ru_zh_v18_cass
+      DATABASE: aida_20180120_cs_de_en_es_ru_zh_v18
+      DOWNLOAD_HOST: http://ambiversenlu-download.mpi-inf.mpg.de/
+    entrypoint: [ "/cassandra-init.sh", "http://ambiversenlu-download.mpi-inf.mpg.de/", "-d", "aida_20180120_cs_de_en_es_ru_zh_v18", "-ch", "nlu-cassandra", "-cp","9042", "-s", "-t", "720", "--", "mvn", "jetty:run" ]
+    deploy:
+      replicas: 1
+        resources:
+          limits:
+            memory: 44G
+    volumes:
+      - "nlu-caches:/var/lib/jetty/caches/aida_20180120_cs_de_en_es_ru_zh_v18_cass/"
+      - "nlu-logs:/var/lib/jetty/logs"
+      - type: tmpfs
+        target: /var/tmp/data
+        tmpfs:
+        size: 107374182400
+    networks:
+      - nlunet
+    healthcheck:
+      test: curl -sS http://127.0.0.1:8080/v2/entitylinking/analyze/_status || exit 1
+      interval: 60s
+      timeout: 60s
+      retries: 10
+      start_period: 5m
+
+volumes:
+  cassandra_data:
+  nlu-caches:
+  nlu-logs:
+
+networks:
+  nlunet:
 ~~~~~~~~
 
 Run `docker stack deploy -c service-cassandra.yml cassandra` (or `docker-compose -f service-cassandra.yml up`), wait for it to initialize completely.
-
-If you want to create a cluster of nodes, you can add another db service, and add the `CASSANDRA_SEEDS` env variable with values of both services, like this:
-
-~~~~~~~~
-version: '3.1'
-
-services:
-
-  db:
-    image: ambiverse/nlu-db-cassandra
-    restart: always
-    environment:
-      DATABASE_NAME: aida_20180120_2f_de_en_v18
-      CASSANDRA_SEEDS: db,db1
-  db1:
-      image: ambiverse/nlu-db-cassandra
-      restart: always
-      environment:
-        DATABASE_NAME: aida_20180120_2f_de_en_v18
-        CASSANDRA_SEEDS: db,db1
-
-  nlu:
-    image: ambiverse/ambiverse-nlu
-    restart: always
-    depends_on:
-      - db
-      - db1
-    ports:
-      - 8080:8080
-    environment:
-      AIDA_CONF: aida_20180120_2f_de_en_v18_cass
-~~~~~~~~

--- a/nlu-db-cassandra/docker-entrypoint.sh
+++ b/nlu-db-cassandra/docker-entrypoint.sh
@@ -1,90 +1,6 @@
 #!/bin/bash
 set -e
 
-# execute a cql file as a string statement to cqlsh
-_execute() {
-	statement=$(<$1)
-	until echo "$statement" | cqlsh; do
-		echo "cqlsh: Cassandra is unavailable - retry later"
-		sleep 2
-	done
-}
-
-# determing how to execute the file based on extention
-_process_init_file() {
-	local f="$1"; shift
-
-	case "$f" in
- 		*.sh)     echo "$0: running $f"; . "$f" ;;
-		*.cql)    echo "$0: running $f"; _execute "$f"; echo ;;
-		*.cql.gz) echo "$0: running $f"; gunzip -c "$f" | _execute; echo ;;
-		*)        echo "$0: ignoring $f" ;;
-	esac
-}
-
-_check_files() {
-	until cqlsh -e 'describe cluster'; do
-		# processing the files in the data directory
-		echo "Cassandra service is still starting up, waiting for it...";
-		sleep 30
-	done
-	echo "Cassandra service ready, starting to import.";
-	for f in ${DATA_PATH}/*; do
-		echo "processing file $f"
-		_process_init_file "$f"
-	done
-}
-
-
-_extract_data() {
-    if [ "$DATABASE_NAME" ]
-    then
-        if [ -d "${DATA_PATH}" ]
-        then
-            cd ${DATA_PATH}/
-            #Move the data to the folders
-            for D in `find . -maxdepth 1 -type d -printf "%f\n"`
-            do
-              echo "Moving files from: $D"
-              cd ${DATA_PATH}/$D
-              for D1 in `find . -maxdepth 1 -type d -printf "%f\n"`
-              do
-                if [ -d $D1/snapshots/*/ ]
-                then
-                  mv $D1/snapshots/*/* /var/lib/cassandra/data/${D}/$(echo $D1| cut -d'-' -f 1)*/
-                   #refresh the moved data
-                  echo "Refreshing data for ${D} $(echo $D1| cut -d'-' -f 1)"
-                  nodetool refresh ${D} $(echo $D1| cut -d'-' -f 1)
-                fi
-              done
-              cd ..
-            done
-         fi
-     fi
-}
-
-_remove_data_tmp(){
-    if [ "${DATA_PATH}" ]
-    then
-        cd ${DATA_PATH}/
-        rm -rf *
-    fi
-}
-
-_download_dump(){
-    local dump="$1"
-    if [ ! -d "/var/lib/cassandra/data/$dump" ]
-    then
-       echo "Downloading dump from http://ambiversenlu-download.mpi-inf.mpg.de/cassandra/$dump.tar.gz ..."
-
-       wget -q --no-cookies -O - "http://ambiversenlu-download.mpi-inf.mpg.de/cassandra/$dump.tar.gz" \
-       | tar xz --directory=${DATA_PATH} -f -
-       echo "Download finished!"
-    else
-        echo "Using existing keyspace $dump ."
-    fi
-}
-
 # first arg is `-f` or `--some-option`
 # or there are no args
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
@@ -93,49 +9,33 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
+	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \
+		\! -user cassandra -exec chown cassandra '{}' +
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 
 _ip_address() {
 	# scrape the first non-localhost IP address of the container
 	# in Swarm Mode, we often get two IPs -- the container IP, and the (shared) VIP, and the container IP should always be first
-	ip address | awk '
-		$1 == "inet" && $NF != "lo" {
-			gsub(/\/.+$/, "", $2)
-			print $2
-			exit
-		}
-	'
+	#ip address | awk '
+	#	$1 == "inet" && $NF != "lo" {
+	#		gsub(/\/.+$/, "", $2)
+	#		print $2
+	#		exit
+	#	}
+	#'
+	ip -o -4 addr list eth0 | sed -n 1p | awk '{print $4}' | cut -d/ -f1
 }
 
-
-# first test if the "data" directory exists and contains files
-if [ -d "${DATA_PATH}" ]; then
-
-    if [ "$DATABASE_NAME" ]; then
-        _remove_data_tmp
-         _download_dump "${DATABASE_NAME}"
-    fi
-
-	if [ ! -z "$(ls -A ${DATA_PATH})" ]; then
-		# if there is an init-db.cql file, we probably want it to be executed first
-		# I rename it because scripts are executed in alphabetic order
-		exec "$@" &
-		if [ -e ${DATA_PATH}/init-db.cql ]
-		then
-			echo "Found an init-db.cql file"
-			mv ${DATA_PATH}/init-db.cql ${DATA_PATH}/1-init-db.cql
-		fi
-		_check_files
-	    #Extract the data after the keyspace schema is created
-
-	    _extract_data
-		# after the files are loaded, restart cassandra with the normal settings.
-		pkill -f 'java.*cassandra'
-	fi
-fi
-
+# "sed -i", but without "mv" (which doesn't work on a bind-mounted file, for example)
+_sed-in-place() {
+	local filename="$1"; shift
+	local tempFile
+	tempFile="$(mktemp)"
+	sed "$@" "$filename" > "$tempFile"
+	cat "$tempFile" > "$filename"
+	rm "$tempFile"
+}
 
 if [ "$1" = 'cassandra' ]; then
 	: ${CASSANDRA_RPC_ADDRESS='0.0.0.0'}
@@ -157,7 +57,8 @@ if [ "$1" = 'cassandra' ]; then
 	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
 
-	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
+	_sed-in-place "$CASSANDRA_CONFIG/cassandra.yaml" \
+		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
 
 	for yaml in \
 		broadcast_address \
@@ -172,7 +73,8 @@ if [ "$1" = 'cassandra' ]; then
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"
 		if [ "$val" ]; then
-			sed -ri 's/^(# )?('"$yaml"':).*/\2 '"$val"'/' "$CASSANDRA_CONFIG/cassandra.yaml"
+			_sed-in-place "$CASSANDRA_CONFIG/cassandra.yaml" \
+				-r 's/^(# )?('"$yaml"':).*/\2 '"$val"'/'
 		fi
 	done
 
@@ -180,7 +82,8 @@ if [ "$1" = 'cassandra' ]; then
 		var="CASSANDRA_${rackdc^^}"
 		val="${!var}"
 		if [ "$val" ]; then
-			sed -ri 's/^('"$rackdc"'=).*/\1 '"$val"'/' "$CASSANDRA_CONFIG/cassandra-rackdc.properties"
+			_sed-in-place "$CASSANDRA_CONFIG/cassandra-rackdc.properties" \
+				-r 's/^('"$rackdc"'=).*/\1 '"$val"'/'
 		fi
 	done
 fi

--- a/nlu-db-cassandra/ready-probe.sh
+++ b/nlu-db-cassandra/ready-probe.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ip_address() {
+	# scrape the first non-localhost IP address of the container
+	# in Swarm Mode, we often get two IPs -- the container IP, and the (shared) VIP, and the container IP should always be first
+	#ip address | awk '
+	#	$1 == "inet" && $NF != "lo" {
+	#		gsub(/\/.+$/, "", $2)
+	#		print $2
+	#		exit
+	#	}
+	#'
+	ip -o -4 addr list eth0 | sed -n 1p | awk '{print $4}' | cut -d/ -f1
+}
+
+if [[ $(nodetool status | grep "$(_ip_address)") == *"UN"* ]]; then
+  if [[ $DEBUG ]]; then
+    echo "UN";
+  fi
+  exit 0;
+else
+  if [[ $DEBUG ]]; then
+    echo "Not Up";
+  fi
+  exit 1;
+fi
+


### PR DESCRIPTION
- Adapting the Cassandra version to 3.11.4. 
- Adding `ready-probe.sh` script to check if Cassandra is up and running. 
- Removing the downloading of the Cassandra dumps from `docker-entrypoint.sh` in the Cassandra image. Cassandra is now independent from the database dump. The dump population is triggered from the NLU image. This will allow having the same Cassandra installation and dumps based on the configuration and the version of NLU. 
- Adapted the `docker-compose` and `swarm stack` configuration in the README.md to reflect the changes. 